### PR TITLE
[#38] ensia96 (2026-03-05)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,5 @@
   },
   "type": "module",
   "types": "dist/src/index.d.ts",
-  "version": "0.0.17"
+  "version": "0.0.18"
 }


### PR DESCRIPTION
## Summary

누락된 버전 업데이트 (v0.0.18) 반영

## Why

PR #40 머지 시 버전 업데이트 커밋이 누락되어 npm publish 실패. 버전을 0.0.18로 올려 배포 가능하게 함

## Verification

- [x] package.json version 0.0.18 확인
- [x] npm publish 성공 확인

## Links

Relates to #38