### PR TITLE
[ensia96] 2026-07-10 14:53:22

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,5 @@
   },
   "type": "module",
   "types": "dist/src/index.d.ts",
-  "version": "0.1.3"
+  "version": "0.1.4"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,6 @@ const plugin: Plugin = async () => {
           "*sudo *": "ask",
         },
       };
-      config.tools = { grep: false };
     },
     tool: Tool.box,
   };

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -18,56 +18,6 @@ export namespace Tool {
     abstract readonly name: string;
   }
 
-  export class FindFiles extends Interface {
-    config = tool({
-      args: {
-        content: is.string().optional().describe("내용 정규표현식 패턴"),
-        cursor: is.number().optional().describe("이전 조회 마지막 mtime"),
-        directory: is
-          .string()
-          .optional()
-          .describe("검색 범위 절대 경로(기본: cwd)"),
-        path: is.string().optional().describe("경로 정규표현식 패턴"),
-      },
-      description: "파일 검색 (mtime 내림차순, 10개 단위)",
-      async execute({ content, cursor, directory = process.cwd(), path }) {
-        try {
-          return JSON.stringify(
-            $.pipe(
-              ...(content
-                ? [
-                    _`ag -l`,
-                    path && _`-G ${path}`,
-                    _`${content}`,
-                    _`${directory}`,
-                  ]
-                : [
-                    _`find ${directory} -type f 2>/dev/null`,
-                    path && _`| grep -E ${path}`,
-                  ]),
-              _`| xargs stat -f '%m\t%z\t%N' 2>/dev/null`,
-              cursor ? _`| awk -F'\t' '$1 < ${cursor}'` : null,
-              _`| sort -rn | head -10`,
-            )
-              .split("\n")
-              .filter(Boolean)
-              .map((line) => {
-                const [mtime, size, ...pathParts] = line.split("\t");
-                return {
-                  mtime: Number(mtime),
-                  path: pathParts.join("\t"),
-                  size: Number(size),
-                };
-              }),
-          );
-        } catch (error) {
-          return FindFiles.handles(error);
-        }
-      },
-    });
-    name = "find-files";
-  }
-
   export namespace Git {
     export class Branch extends Interface {
       config = tool({
@@ -410,7 +360,6 @@ export namespace Tool {
   }
 
   export const box: Record<string, ToolDefinition> = [
-    new FindFiles(),
     new Git.Branch(),
     new Git.Commit(),
     new Git.Issue(),

--- a/verify.sh
+++ b/verify.sh
@@ -7,9 +7,8 @@ if [[ "${CI:-}" != "true" ]]; then
   exit 1
 fi
 
-# v0.1.3 도구, 스킬 및 에이전트 검증
-EXPECTED="find-files
-git-branch
+# v0.1.4 도구, 스킬 및 에이전트 검증
+EXPECTED="git-branch
 git-commit
 git-issue
 git-request-merge
@@ -32,7 +31,7 @@ echo "$ACTUAL"
 echo ""
 
 if [[ "$ACTUAL" == "$EXPECTED" ]]; then
-  echo "✅ 도구 목록 일치 (10개)"
+  echo "✅ 도구 목록 일치 (9개)"
 else
   echo "❌ 도구 목록 불일치"
   echo ""


### PR DESCRIPTION
## Summary

grep 제한을 해제하고 find-files 도구를 제거했으며, verify.sh 도구 검증을 9개 기준으로 갱신하고 버전을 0.1.4로 올렸습니다.

## Why

기본 grep 도구 사용을 허용하고 중복 파일 탐색 도구를 정리한 배포 변경사항을 dev -> main 흐름으로 검증하기 위함입니다.

## Verification

- [ ] git diff --check
- [ ] bun run build
- [ ] CI=true bash verify.sh
- [ ] npm pack --dry-run

## Links

-